### PR TITLE
changed "parodos" to "Red Hat Developer Hub Orchestrator"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 parodos-dev.github.io 
 
-This site is built by hugo static site generater and published using a github action to https://parodos.dev
+This site is built by hugo static site generater and published using a github action to https://rhdho.dev
 
 # Devleopment
 - Requiremens

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Parodos: Workflows for Backstsage"
+title: "Red Hat Developer Hub Orchestrator: Workflows for Backstsage"
 ---
 
 {{< blocks/cover title="Orchestrating Systems | Migrating Code Infrastructure | Keeping Developers in Sync"  color="primary" image_anchor="top" height="min" >}}
@@ -14,7 +14,7 @@ title: "Parodos: Workflows for Backstsage"
 {{< /blocks/cover >}}
 
 {{% blocks/lead color="primary" %}}
-Parodos brings serverless workflows into backstage, focusing on the journey for application migration to the cloud, on boarding developers , and user-made workflows of backstage actions or external systems.
+Red Hat Developer Hub Orchestrator brings serverless workflows into backstage, focusing on the journey for application migration to the cloud, on boarding developers , and user-made workflows of backstage actions or external systems.
 
 {{% /blocks/lead %}}
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,6 +1,6 @@
-baseURL: https://parodos.dev
+baseURL: https://rhdho.dev
 languageCode: en-us
-title: Parodos Dev
+title: Red Hat Developer Hub Orchestrator 
 SectionPagesMenu : "main"
 enableRobotsTXT : true
 theme: 
@@ -34,12 +34,12 @@ markup:
 params:
   copyright:
     authors: >-
-      Parodos Authors|
+       Red Hat Developer Hub Orchestrator Authors|
       [CC BY 4.0](https://creativecommons.org/licenses/by/4.0) |
     from_year: 2023
       #privacy_policy: link to privacy policy
   version_menu: Releases
-  url_latest_version: https://parodos.dev
+  url_latest_version: https://rhdho.dev
   github_repo: https://github.com/parodos-dev/parodos-dev.github.io
   github_project_repo: https://github.com/parodos-dev/parodos-dev.github.io
   time_format_blog: Monday, January 02, 2006


### PR DESCRIPTION
This PR starts the change from parodos to something else (right now "Red Hat Developer Hub Orchestrator"). As a first step, after merging we could point the dns entry for `rhdho.dev` to `parodos-dev.github.io`, much like `parodos.dev` is today.