### PR TITLE
Update references to serverless-workflow repository

### DIFF
--- a/content/1.4/docs/core-concepts/workflow-types/_index.md
+++ b/content/1.4/docs/core-concepts/workflow-types/_index.md
@@ -5,7 +5,7 @@ date: 2024-05-07
 
 
 > **🚨 Deprecation Notice: 🚨**  
-> In the next Orchestrator release, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assesment workflow. <br>
+> In the next Orchestrator release, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assessment workflow. <br>
 
 
 The Orchestrator features two primary workflow categories:

--- a/content/1.4/docs/installation/workflows/deploy-from-helm-repository.md
+++ b/content/1.4/docs/installation/workflows/deploy-from-helm-repository.md
@@ -3,4 +3,4 @@ title: Deploy From Helm Repository
 date: "2024-02-20"
 ---
 
-{{< remoteMD "https://raw.githubusercontent.com/rhdhorchestrator/serverless-workflows-config/refs/heads/gh-pages/docs/README.md" >}}
+{{< remoteMD "https://raw.githubusercontent.com/rhdhorchestrator/serverless-workflows/refs/heads/gh-pages/README.md" >}}

--- a/content/1.4/docs/quickstart/index.md
+++ b/content/1.4/docs/quickstart/index.md
@@ -12,7 +12,7 @@ This quickstart guide will help you install the Orchestrator using the Helm-base
    Follow the [installation instructions for Orchestrator](/main/docs/installation/).
 
 2. **Install a sample workflow**:
-   Follow the [installation instructions for the greetings workflow](https://github.com/rhdhorchestrator/serverless-workflows-config/blob/main/docs/release-1.4/greeting/README.md).
+   Follow the [installation instructions for the greetings workflow](https://github.com/rhdhorchestrator/serverless-workflows/blob/main/deploy/docs/release-1.5/greeting/README.md).
 
 3. **Access Red Hat Developer Hub**:
    Open your web browser and navigate to the Red Hat Developer Hub application. Retrieve the URL using the following OpenShift CLI command.

--- a/content/1.5/docs/core-concepts/workflow-types/_index.md
+++ b/content/1.5/docs/core-concepts/workflow-types/_index.md
@@ -4,7 +4,7 @@ date: 2024-05-07
 ---
 
 > **🚨 Deprecation Notice: 🚨**  
-> In the next Orchestrator release, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assesment workflow. <br>
+> In the next Orchestrator release, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assessment workflow. <br>
 
 The Orchestrator features two primary workflow categories:
 - *Infrastructure workflows*: focus on automating infrastructure-related tasks

--- a/content/1.5/docs/installation/workflows/deploy-from-helm-repository.md
+++ b/content/1.5/docs/installation/workflows/deploy-from-helm-repository.md
@@ -3,4 +3,4 @@ title: Deploy From Helm Repository
 date: "2024-02-20"
 ---
 
-{{< remoteMD "https://raw.githubusercontent.com/rhdhorchestrator/serverless-workflows-config/refs/heads/gh-pages/docs/README.md" >}}
+{{< remoteMD "https://raw.githubusercontent.com/rhdhorchestrator/serverless-workflows/refs/heads/gh-pages/README.md" >}}

--- a/content/1.5/docs/quickstart/index.md
+++ b/content/1.5/docs/quickstart/index.md
@@ -12,7 +12,7 @@ This quickstart guide will help you install the Orchestrator using the Helm-base
    Follow the [installation instructions for Orchestrator](/main/docs/installation/).
 
 2. **Install a sample workflow**:
-   Follow the [installation instructions for the greetings workflow](https://github.com/rhdhorchestrator/serverless-workflows-config/blob/main/docs/release-1.5/greeting/README.md).
+   Follow the [installation instructions for the greetings workflow](https://github.com/rhdhorchestrator/serverless-workflows/blob/main/deploy/docs/release-1.5/greeting/README.md).
 
 3. **Access Red Hat Developer Hub**:
    Open your web browser and navigate to the Red Hat Developer Hub application. Retrieve the URL using the following OpenShift CLI command.

--- a/content/blog/developer-experience-detailed.md
+++ b/content/blog/developer-experience-detailed.md
@@ -51,7 +51,7 @@ On the second screen, you'll need to select the workflow type. You can learn mor
 - **Workflow Type** - There are two supported types: infrastructure for operations returning output, and assessment for evaluation/assessment leading to potential infrastructure workflows.
 
 > **🚨 Deprecation Notice: 🚨**  
-> In the next Orchestrator release, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assesment workflow. <br>
+> In the next Orchestrator release, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assessment workflow. <br>
 > The following document will relevant up to Orchestrator version 1.6.
 
 On the final screen, you'll be prompted to input the CI/CD parameters and persistence-related parameters.
@@ -60,7 +60,7 @@ On the final screen, you'll be prompted to input the CI/CD parameters and persis
 - **GitOps Namespace** - Namespace for GitOps secrets and ArgoCD application creation. The default *orchestrator-gitops* complies with the default installation steps of the Orchestrator deployment.
 - **Quay Organization Name** - Organization name in Quay for the published workflow. The Tekton pipeline pushes the workflow to this organization.
 - **Quay Repository Name** - Repository name in Quay for the published workflow, which must exist before deploying GitOps. The secret created in the GitOps Namespace needs permission to push to this repository.
-- **Enable Persistance** - Check this option to enable persistence for the workflow. It ensures each workflow persists its instances in a configured database schema, with the schema name matching the workflow ID. Persistence is recommended for long-running workflows and to support the Abort operation.
+- **Enable Persistence** - Check this option to enable persistence for the workflow. It ensures each workflow persists its instances in a configured database schema, with the schema name matching the workflow ID. Persistence is recommended for long-running workflows and to support the Abort operation.
 - **Database properties** - Self-explanatory list of database properties.
 
 After providing all parameters, click Review, ensure correctness, and then click Create. Successful creation leads to:

--- a/content/main/docs/core-concepts/workflow-types/_index.md
+++ b/content/main/docs/core-concepts/workflow-types/_index.md
@@ -4,7 +4,7 @@ date: 2024-05-07
 ---
 
 > **🚨 Deprecation Notice: 🚨**  
-> In the next Orchestrator release, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assesment workflow. <br>
+> In the next Orchestrator release, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assessment workflow. <br>
 > The following document will relevant up to Orchestrator version 1.6.
 
 
@@ -71,7 +71,6 @@ The *workflowOptions* object must possess six essential attributes with specific
 
 ##### Examples:
 - [MTA](https://github.com/rhdhorchestrator/serverless-workflows/blob/main/workflows/mta-v7.x/mta.sw.yaml)
-- [Dummy Assessment](https://github.com/rhdhorchestrator/serverless-workflow-examples/tree/main/assessment)
 
 #### Note
 If the aforementioned annotation is missing in the workflow definition file, the Orchestrator plugin will default to treating the workflow as an infrastructure workflow, without considering its output.

--- a/content/main/docs/installation/workflows/deploy-from-helm-repository.md
+++ b/content/main/docs/installation/workflows/deploy-from-helm-repository.md
@@ -3,4 +3,4 @@ title: Deploy From Helm Repository
 date: "2024-02-20"
 ---
 
-{{< remoteMD "https://raw.githubusercontent.com/rhdhorchestrator/serverless-workflows-config/refs/heads/gh-pages/docs/README.md" >}}
+{{< remoteMD "https://raw.githubusercontent.com/rhdhorchestrator/serverless-workflows/refs/heads/gh-pages/README.md" >}}

--- a/content/main/docs/quickstart/index.md
+++ b/content/main/docs/quickstart/index.md
@@ -12,7 +12,7 @@ This quickstart guide will help you install the Orchestrator using the Helm-base
    Follow the [installation instructions for Orchestrator](/main/docs/installation/).
 
 2. **Install a sample workflow**:
-   Follow the [installation instructions for the greetings workflow](https://github.com/rhdhorchestrator/serverless-workflows-config/blob/main/docs/main/greeting/README.md).
+   Follow the [installation instructions for the greetings workflow](https://github.com/rhdhorchestrator/serverless-workflows/blob/main/deploy/docs/main/greeting/README.md).
 
 3. **Access Red Hat Developer Hub**:
    Open your web browser and navigate to the Red Hat Developer Hub application. Retrieve the URL using the following OpenShift CLI command.


### PR DESCRIPTION
After the merge of serverless-workflow-config repository with serverless-workflow, there is a need to update the references to point to the merged repository.